### PR TITLE
phrase filter does not get individual document, so use get_solr_response_for_doc_id

### DIFF
--- a/lib/blacklight_oai_provider/solr_document_wrapper.rb
+++ b/lib/blacklight_oai_provider/solr_document_wrapper.rb
@@ -5,7 +5,7 @@ module BlacklightOaiProvider
     def initialize(controller, options = {})
       @controller = controller
 
-      defaults = { :timestamp => 'timestamp', :limit => 15} 
+      defaults = { :timestamp => 'timestamp', :limit => 15}
       @options = defaults.merge options
 
       @timestamp_field = @options[:timestamp]
@@ -32,8 +32,8 @@ module BlacklightOaiProvider
         if @limit && response.total >= @limit
           return select_partial(OAI::Provider::ResumptionToken.new(options.merge({:last => 0})))
         end
-      else                                                    
-        records = @controller.get_search_results(@controller.params, {:phrase_filters => {:id => selector.split('/', 2).last}}).last.first
+      else
+        response, records = @controller.get_solr_response_for_doc_id selector.split('/', 2).last
       end
       records
     end


### PR DESCRIPTION
When trying to retrieve an individual resource I was always getting the same resource no matter what the id in the URL was. I changed BlacklightOaiProvider::SolrDocumentWrapper to use #get_solr_response_for_doc_id which now returns the correct resource record.
