### PR TITLE
Fix typo in sample config code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ configure_blacklight do |config|
       sample_id: '109660'
     },
     document: {
-      limit: 25            # number of records returned with each request, default: 15
+      limit: 25,            # number of records returned with each request, default: 15
       set_fields: [        # ability to define ListSets, optional, default: nil
         { label: 'language', solr_field: 'language_facet' }
       ]


### PR DESCRIPTION
Just adding a missing comma so that the sample configuration code in the readme works out of the box