### PR TITLE
fix default options set at SolrDocumentProvider

### DIFF
--- a/lib/blacklight_oai_provider/solr_document_provider.rb
+++ b/lib/blacklight_oai_provider/solr_document_provider.rb
@@ -8,8 +8,8 @@ module BlacklightOaiProvider
 
       self.class.model = SolrDocumentWrapper.new(controller, options[:document])
 
-      options[:repository_name] ||= controller.view_context.send(:application_name)
-      options[:repository_url] ||= controller.view_context.send(:oai_catalog_url)
+      options[:provider][:repository_name] ||= controller.view_context.application_name
+      options[:provider][:repository_url] ||= controller.view_context.oai_catalog_url
 
       options[:provider].each do |k, v|
         self.class.send k, v

--- a/lib/blacklight_oai_provider/solr_document_provider.rb
+++ b/lib/blacklight_oai_provider/solr_document_provider.rb
@@ -12,6 +12,7 @@ module BlacklightOaiProvider
       options[:provider][:repository_url] ||= controller.view_context.oai_catalog_url
 
       options[:provider].each do |k, v|
+        v = v.call(controller) if v.is_a?(Proc)
         self.class.send k, v
       end
     end

--- a/spec/lib/blacklight_oai_provider/solr_document_provider_spec.rb
+++ b/spec/lib/blacklight_oai_provider/solr_document_provider_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe BlacklightOaiProvider::SolrDocumentProvider do
   let(:options) { {} }
   let(:controller) { CatalogController.new }
 
-
   describe '#initialize' do
-    let(:view_context) { double("ViewContext") }
+    let(:view_context) { instance_double("ViewContext") }
 
     before do
       allow(controller).to receive(:view_context).and_return(view_context)
@@ -21,7 +20,6 @@ RSpec.describe BlacklightOaiProvider::SolrDocumentProvider do
         expect(provider.url).to eq :some_path
         expect(provider.name).to eq :some_name
       end
-
     end
 
     context 'with options provided' do
@@ -30,6 +28,21 @@ RSpec.describe BlacklightOaiProvider::SolrDocumentProvider do
       it 'uses the repository name and url set into the options' do
         expect(provider.url).to eq '/my/custom/path'
         expect(provider.name).to eq 'My Custom Name'
+      end
+    end
+
+    context 'with Procs provided as option values' do
+      let(:options) {
+        {
+            provider: {
+                repository_name: ->(kontroller) { "Hello #{kontroller.__id__}" },
+                repository_url: ->(kontroller) { "Hello #{kontroller.view_context.oai_catalog_url}" },
+            }
+        }
+      }
+      it 'call()-s the Proc to set the option value' do
+        expect(provider.name).to eq "Hello #{controller.__id__}"
+        expect(provider.url).to eq "Hello #{controller.view_context.oai_catalog_url}"
       end
     end
   end

--- a/spec/lib/blacklight_oai_provider/solr_document_provider_spec.rb
+++ b/spec/lib/blacklight_oai_provider/solr_document_provider_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe BlacklightOaiProvider::SolrDocumentProvider do
+  subject(:provider) { described_class.new(controller, options) }
+
+  let(:options) { {} }
+  let(:controller) { CatalogController.new }
+
+
+  describe '#initialize' do
+    let(:view_context) { double("ViewContext") }
+
+    before do
+      allow(controller).to receive(:view_context).and_return(view_context)
+      allow(view_context).to receive(:oai_catalog_url).and_return(:some_path)
+      allow(view_context).to receive(:application_name).and_return(:some_name)
+    end
+
+    context 'with no options provided' do
+      it 'sets the default repository name and url' do
+        expect(provider.url).to eq :some_path
+        expect(provider.name).to eq :some_name
+      end
+
+    end
+
+    context 'with options provided' do
+      let(:options) { { provider: { repository_url: '/my/custom/path', repository_name: 'My Custom Name' } } }
+
+      it 'uses the repository name and url set into the options' do
+        expect(provider.url).to eq '/my/custom/path'
+        expect(provider.name).to eq 'My Custom Name'
+      end
+    end
+  end
+end

--- a/spec/lib/blacklight_oai_provider/solr_document_provider_spec.rb
+++ b/spec/lib/blacklight_oai_provider/solr_document_provider_spec.rb
@@ -32,14 +32,15 @@ RSpec.describe BlacklightOaiProvider::SolrDocumentProvider do
     end
 
     context 'with Procs provided as option values' do
-      let(:options) {
+      let(:options) do
         {
-            provider: {
-                repository_name: ->(kontroller) { "Hello #{kontroller.__id__}" },
-                repository_url: ->(kontroller) { "Hello #{kontroller.view_context.oai_catalog_url}" },
-            }
+          provider: {
+            repository_name: ->(kontroller) { "Hello #{kontroller.__id__}" },
+            repository_url: ->(kontroller) { "Hello #{kontroller.view_context.oai_catalog_url}" }
+          }
         }
-      }
+      end
+
       it 'call()-s the Proc to set the option value' do
         expect(provider.name).to eq "Hello #{controller.__id__}"
         expect(provider.url).to eq "Hello #{controller.view_context.oai_catalog_url}"


### PR DESCRIPTION
It just changes the hash key names of the options hash to put them into the :provider key.