### PR TITLE
Set earliest/latest timestamp to current time for empty results

### DIFF
--- a/lib/blacklight_oai_provider/solr_document_wrapper.rb
+++ b/lib/blacklight_oai_provider/solr_document_wrapper.rb
@@ -25,13 +25,13 @@ module BlacklightOaiProvider
     def earliest
       builder = search_service.search_builder.merge(fl: solr_timestamp, sort: "#{solr_timestamp} asc", rows: 1)
       response = search_service.repository.search(builder)
-      response.documents.first.timestamp
+      response.documents.first&.timestamp&.presence || Time.now.to_s
     end
 
     def latest
       builder = search_service.search_builder.merge(fl: solr_timestamp, sort: "#{solr_timestamp} desc", rows: 1)
       response = search_service.repository.search(builder)
-      response.documents.first.timestamp
+      response.documents.first&.timestamp&.presence || Time.now.to_s
     end
 
     def find(selector, options = {})

--- a/lib/blacklight_oai_provider/solr_document_wrapper.rb
+++ b/lib/blacklight_oai_provider/solr_document_wrapper.rb
@@ -25,13 +25,13 @@ module BlacklightOaiProvider
     def earliest
       builder = search_service.search_builder.merge(fl: solr_timestamp, sort: "#{solr_timestamp} asc", rows: 1)
       response = search_service.repository.search(builder)
-      response.documents.first&.timestamp&.presence || Time.now.to_s
+      timestamp_presence(response.documents.first)
     end
 
     def latest
       builder = search_service.search_builder.merge(fl: solr_timestamp, sort: "#{solr_timestamp} desc", rows: 1)
       response = search_service.repository.search(builder)
-      response.documents.first&.timestamp&.presence || Time.now.to_s
+      timestamp_presence(response.documents.first)
     end
 
     def find(selector, options = {})
@@ -93,6 +93,11 @@ module BlacklightOaiProvider
       else
         time.to_s
       end
+    end
+
+    def timestamp_presence(solr_doc)
+      return solr_doc.timestamp.presence if solr_doc && solr_doc.timestamp
+      Time.now.utc.to_s
     end
   end
 end

--- a/spec/integration/blacklight_oai_provider/solr_document_wrapper_spec.rb
+++ b/spec/integration/blacklight_oai_provider/solr_document_wrapper_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+RSpec.describe BlacklightOaiProvider::SolrDocumentWrapper do
+  subject(:wrapper) { described_class.new(controller, options) }
+
+  let(:options) { {} }
+  let(:controller_class) { CatalogController }
+  let(:controller) { controller_class.new }
+
+  before do
+    allow(controller).to receive(:params).and_return({})
+  end
+
+  describe '#earliest' do
+    it 'returns the earliest timestamp of all the records' do
+      expect(wrapper.earliest).to eq Time.parse('2014-02-03 18:42:53.056000000 +0000').utc
+    end
+  end
+
+  describe '#latest' do
+    it 'returns the latest timestamp of all the records' do
+      expect(wrapper.latest).to eq Time.parse('2015-02-03 18:42:53.056000000 +0000').utc
+    end
+  end
+
+  describe '#find' do
+    context 'when selector is :all' do
+      it 'returns a limited list of all records' do
+        expect(wrapper.find(:all)).to be_a OAI::Provider::PartialResult
+        expect(wrapper.find(:all).records.size).to be 15
+      end
+    end
+
+    context 'when selector is an individual record' do
+      let(:search_builder_class) do
+        Class.new(Blacklight::SearchBuilder) do
+          include Blacklight::Solr::SearchBuilderBehavior
+          self.default_processor_chain += [:only_visible]
+
+          def only_visible(solr_parameters)
+            solr_parameters[:fq] ||= []
+            solr_parameters[:fq] << 'visibility_si:"open"'
+          end
+        end
+      end
+      let(:controller_class) do
+        stub_const 'VisibilitySearchBuilder', search_builder_class
+        Class.new(CatalogController) do
+          blacklight_config.configure do |config|
+            config.search_builder_class = VisibilitySearchBuilder
+          end
+        end
+      end
+
+      it 'returns nothing for a restricted work' do
+        expect(wrapper.find('2007020969')).to be_nil
+      end
+
+      it 'returns a single record for a public work' do
+        expect(wrapper.find('2005553155')).to be_a SolrDocument
+      end
+    end
+  end
+end

--- a/spec/lib/blacklight_oai_provider/solr_document_wrapper_spec.rb
+++ b/spec/lib/blacklight_oai_provider/solr_document_wrapper_spec.rb
@@ -52,20 +52,22 @@ RSpec.describe BlacklightOaiProvider::SolrDocumentWrapper do
     end
 
     context 'when selector is an individual record' do
-      class VisibilityAwareSearchBuilder < Blacklight::SearchBuilder
-        include Blacklight::Solr::SearchBuilderBehavior
-        self.default_processor_chain += [:only_visible]
+      let(:search_builder_class) do
+        Class.new(Blacklight::SearchBuilder) do
+          include Blacklight::Solr::SearchBuilderBehavior
+          self.default_processor_chain += [:only_visible]
 
-        def only_visible(solr_parameters)
-          solr_parameters[:fq] ||= []
-          solr_parameters[:fq] << 'visibility_si:"open"'
+          def only_visible(solr_parameters)
+            solr_parameters[:fq] ||= []
+            solr_parameters[:fq] << 'visibility_si:"open"'
+          end
         end
       end
-
       let(:controller_class) do
+        stub_const 'VisibilitySearchBuilder', search_builder_class
         Class.new(CatalogController) do
-          configure_blacklight do |config|
-            config.search_builder_class = VisibilityAwareSearchBuilder
+          blacklight_config.configure do |config|
+            config.search_builder_class = VisibilitySearchBuilder
           end
         end
       end


### PR DESCRIPTION
Fixes #26.

This falls back to a timestamp generated from the current time if there are no Solr documents or timestamps present.

According to [the OAI-PMH spec](http://www.openarchives.org/OAI/openarchivesprotocol.html), the `earliestDatestamp` element this will be used in has the following criteria:

> earliestDatestamp : a UTCdatetime that is the guaranteed lower limit of all datestamps recording changes, modifications, or deletions in the repository. A repository must not use datestamps lower than the one specified by the content of the earliestDatestamp element. earliestDatestamp must be expressed at the finest granularity supported by the repository.

Since in this case there are no records with datestamps, using the current timestamp should be fine, and result in no differences from the case where a repository has a set of records with an earliest datestamp and then later has a new record added later on with an earlier datestamp (since the `earliestDatestamp` will update accordingly).

I've also made a backport onto the v6.1.1 tag here: https://github.com/ryanfb/blacklight_oai_provider/tree/default-earliest-datestamp-6.1.1-backport