### PR TITLE
use instance configuration of oai provider to avoid controller configuration pollution of provider class config

### DIFF
--- a/blacklight_oai_provider.gemspec
+++ b/blacklight_oai_provider.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "blacklight", "~> 7.0"
-  s.add_dependency "oai", "~> 1.0"
+  s.add_dependency "oai", "~> 1.1"
   s.add_dependency "rexml"
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'capybara'

--- a/lib/blacklight_oai_provider/solr_document_provider.rb
+++ b/lib/blacklight_oai_provider/solr_document_provider.rb
@@ -2,23 +2,40 @@ module BlacklightOaiProvider
   class SolrDocumentProvider < ::OAI::Provider::Base
     attr_accessor :options
 
+    PROVIDER_INSTANCE_ATTRS = {
+      name: :repository_name,
+      url: :repository_url,
+      prefix: :record_prefix,
+      email: :admin_email,
+      delete_support: :deletion_support,
+      granularity: :update_granularity,
+      model: :source_model,
+      identifier: :sample_id,
+      description: :extra_description
+    }.freeze
+
     def initialize(controller, options = {})
-      options[:provider] ||= {}
-      options[:document] ||= {}
+      super(options.merge(provider_context: :instance_based))
 
-      self.class.model = SolrDocumentWrapper.new(controller, options[:document])
-
-      options[:provider][:repository_name] ||= controller.view_context.application_name
-      options[:provider][:repository_url] ||= controller.view_context.oai_catalog_url
-
-      options[:provider].each do |k, v|
+      provider_options = convert_to_instance_options(options.fetch(:provider, {}))
+      provider_options[:model] ||= SolrDocumentWrapper.new(controller, options.fetch(:document, {}))
+      provider_options[:name] ||= controller.view_context.application_name
+      provider_options[:url] ||= controller.view_context.oai_catalog_url
+      provider_options.each do |k, v|
         v = v.call(controller) if v.is_a?(Proc)
-        self.class.send k, v
+        send :"#{k}=", v
       end
     end
 
     def list_sets(options = {})
-      Response::ListSets.new(self.class, options).to_xml
+      Response::ListSets.new(self, options).to_xml
+    end
+
+    def convert_to_instance_options(controller_options)
+      instance_options = controller_options.dup
+      PROVIDER_INSTANCE_ATTRS.each { |inst_att, class_att| instance_options[inst_att] ||= instance_options.delete(class_att) }
+      instance_options.delete_if { |k, _v| PROVIDER_INSTANCE_ATTRS[k].nil? }
+      instance_options
     end
   end
 end

--- a/lib/generators/blacklight_oai_provider/install_generator.rb
+++ b/lib/generators/blacklight_oai_provider/install_generator.rb
@@ -31,8 +31,8 @@ module BlacklightOaiProvider
         "\n  concern :oai_provider, BlacklightOaiProvider::Routes.new\n"
       end
 
-      inject_into_file file_path, after: /resource :catalog,+(.*)do$/ do
-        "\n    concerns :oai_provider\n"
+      gsub_file file_path, /concerns :searchable$/ do
+        "concerns :oai_provider\n    concerns :searchable\n"
       end
     end
   end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -19,7 +19,7 @@ describe CatalogController do
     it 'returns correct provider configuration' do
       expect(controller.oai_config).to include(
         provider: {
-          repository_name: "Test Repository",
+          repository_name: "Catalog Repository",
           repository_url: "http://localhost/catalog/oai",
           record_prefix: "oai:test",
           admin_email: "root@localhost",

--- a/spec/lib/blacklight_oai_provider/solr_document_provider_spec.rb
+++ b/spec/lib/blacklight_oai_provider/solr_document_provider_spec.rb
@@ -32,18 +32,33 @@ RSpec.describe BlacklightOaiProvider::SolrDocumentProvider do
     end
 
     context 'with Procs provided as option values' do
+      let(:alternate_controller) { AlternateController.new }
+      let(:alternate_provider) { described_class.new(alternate_controller, options) }
+      let(:alternate_view_context) { instance_double("ViewContext") }
       let(:options) do
         {
           provider: {
-            repository_name: ->(kontroller) { "Hello #{kontroller.__id__}" },
-            repository_url: ->(kontroller) { "Hello #{kontroller.view_context.oai_catalog_url}" }
+            repository_name: ->(kontroller) { "Hello #{kontroller.controller_name.titleize}" },
+            repository_url: ->(kontroller) { "Hello #{kontroller.view_context.send "oai_#{kontroller.controller_name}_url"}" }
           }
         }
       end
 
+      before do
+        allow(alternate_controller).to receive(:view_context).and_return(alternate_view_context)
+        allow(alternate_view_context).to receive(:oai_alternate_url).and_return(:another_path)
+        allow(alternate_view_context).to receive(:application_name).and_return(:another_name)
+      end
+
       it 'call()-s the Proc to set the option value' do
-        expect(provider.name).to eq "Hello #{controller.__id__}"
+        expect(provider.name).to eq "Hello Catalog"
         expect(provider.url).to eq "Hello #{controller.view_context.oai_catalog_url}"
+      end
+
+      it 'does not pollute controller configurations from procs' do
+        provider.name
+        expect(alternate_provider.name).to eq "Hello Alternate"
+        expect(provider.name).to eq "Hello Catalog"
       end
     end
   end

--- a/spec/requests/identify_spec.rb
+++ b/spec/requests/identify_spec.rb
@@ -12,7 +12,7 @@ describe 'OIA-PMH Identify Request' do
   end
 
   it "contains repository name" do
-    expect(xml.at_xpath('//xmlns:repositoryName').text).to eql 'Test Repository'
+    expect(xml.at_xpath('//xmlns:repositoryName').text).to eql 'Catalog Repository'
   end
 
   it "contains base url" do


### PR DESCRIPTION
- include AlternateController from Blacklight test generator in test app
- requires oai 1.1+
- fixes #41

This bug is around the lambda configuration property feature introduced in #22 